### PR TITLE
update conda-forge with explicit conda-lock versions

### DIFF
--- a/conda_vendor/version.py
+++ b/conda_vendor/version.py
@@ -1,6 +1,6 @@
 import click
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 if __name__ == "__main__":
     click.echo(__version__)

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python>=3.7
   - pip
   - click
-  - conda-lock>=1.2.1
+  - conda-lock==1.4.0
   - packaging
   - requests
   - ruamel.yaml

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     },
     install_requires=[
         "click",
-        "conda-lock>=1.2.1",
+        "conda-lock==1.4.0",
         "packaging",
         "requests",
         "ruamel.yaml",


### PR DESCRIPTION
changed the conda-lock version to be explict instead of great than.